### PR TITLE
Remove lazy loading, fix tags

### DIFF
--- a/content/wiki/faq-static-vs-dynamic/index.mdx
+++ b/content/wiki/faq-static-vs-dynamic/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: What is the difference between static and dynamic websites?
 date: 2020-10-09
-tags: ["faq"]
+category: ["faq"]
 published: true
 excerpt: 'What is the difference between static and dynamic websites'
 ---

--- a/content/wiki/faq-what-is-a-cms/index.mdx
+++ b/content/wiki/faq-what-is-a-cms/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: What is a CMS?
 date: 2020-10-09
-tags: ["faq"]
+category: ["faq"]
 published: true
 excerpt: 'What is a CMS?'
 ---

--- a/content/wiki/faq-what-website-do-i-need/index.mdx
+++ b/content/wiki/faq-what-website-do-i-need/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: What type of website do I need?
 date: 2020-10-09
-tags: ["faq"]
+category: ["faq"]
 published: true
 excerpt: 'What type of website do I need?'
 ---

--- a/content/wiki/pricing-payment-terms/index.mdx
+++ b/content/wiki/pricing-payment-terms/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pricing and payment details
 date: 2020-10-09
-tags: ["pricing"]
+category: ["pricing"]
 published: true
 excerpt: 'Pricing and payment details'
 ---

--- a/content/wiki/pricing-updates/index.mdx
+++ b/content/wiki/pricing-updates/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Website updates
 date: 2020-10-09
-tags: ["pricing"]
+category: ["pricing"]
 published: true
 excerpt: 'Updates to your website'
 ---

--- a/content/wiki/pricing-what-do-you-get-design/index.mdx
+++ b/content/wiki/pricing-what-do-you-get-design/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Design - What do you get
 date: 2020-10-09
-tags: ["pricing"]
+category: ["pricing"]
 published: true
 excerpt: 'What do you get design'
 ---

--- a/content/wiki/pricing-what-do-you-get-hosting/index.mdx
+++ b/content/wiki/pricing-what-do-you-get-hosting/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting - What do you get
 date: 2020-10-09
-tags: ["pricing"]
+category: ["pricing"]
 published: true
 excerpt: 'What do you get hosting'
 ---

--- a/content/wiki/procedure-custom-project/index.mdx
+++ b/content/wiki/procedure-custom-project/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Custom Project - How does that work
 date: 2020-10-09
-tags: ["procedure"]
+category: ["procedure"]
 published: true
 excerpt: 'What do I need and what can you expect'
 ---

--- a/content/wiki/procedure-design-project/index.mdx
+++ b/content/wiki/procedure-design-project/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Design Project - How do I work
 date: 2020-10-09
-tags: ["procedure"]
+category: ["procedure"]
 published: true
 excerpt: 'What do I need and what can you expect'
 ---

--- a/content/wiki/procedure-hosting-what-can-you-expect/index.mdx
+++ b/content/wiki/procedure-hosting-what-can-you-expect/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting - What can you expect
 date: 2020-10-09
-tags: ["procedure"]
+category: ["procedure"]
 published: true
 excerpt: 'What can you expect'
 ---

--- a/src/components/portfolioPreview.tsx
+++ b/src/components/portfolioPreview.tsx
@@ -1,12 +1,11 @@
-import React, { lazy, Suspense, useState } from 'react'
+import React, { useState } from 'react'
 import Img from 'gatsby-image/withIEPolyfill'
 import { Button, Card, CardBody, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap'
 import { FaTimes } from 'react-icons/fa'
-const PostBody = lazy(() => import('./postBody'))
-const PostImage = lazy(() => import('./postImage'))
-const PostSubtitle = lazy(() => import('./postSubtitle'))
-const PostTitle = lazy(() => import('./postTitle'))
-import RenderLoader from './renderLoader'
+import PostBody from './postBody'
+import PostImage from './postImage'
+import PostSubtitle from './postSubtitle'
+import PostTitle from './postTitle'
 import { content } from '../utils/data'
 import { PortfolioEntryProps } from '../types'
 
@@ -15,19 +14,14 @@ export default function PortfolioPreview({ body, fields, frontmatter }: Portfoli
     const toggle = () => setModal(!modal);
     const closeBtn = <button className="close" onClick={toggle}>&times;</button>;
 
-    const isSSR = typeof window === "undefined";
     return (
         <>
             <Card>
-                {!isSSR && (
-                    <Suspense fallback={<RenderLoader />}>
-                        <CardBody>
-                            <PostTitle path={false} onClick={toggle} slug={fields.slug} title={frontmatter.title} />
-                            <PostImage path={false} onClick={toggle} slug={fields.slug} title={frontmatter.title} picture={frontmatter.cover.childImageSharp} rounded={true} height={180} />
-                            <PostSubtitle className='mt-3' date={frontmatter.date} tags={frontmatter.tags} />
-                        </CardBody>
-                    </Suspense>
-                )}
+                <CardBody>
+                    <PostTitle path={false} onClick={toggle} slug={fields.slug} title={frontmatter.title} />
+                    <PostImage path={false} onClick={toggle} slug={fields.slug} title={frontmatter.title} picture={frontmatter.cover.childImageSharp} rounded={true} height={180} />
+                    <PostSubtitle className='mt-3' date={frontmatter.date} tags={frontmatter.tags} />
+                </CardBody>
             </Card>
             <Modal isOpen={modal} toggle={toggle} size='lg'>
                 <ModalHeader className='modal-background' toggle={toggle} close={closeBtn}>{frontmatter.title}</ModalHeader>
@@ -37,11 +31,7 @@ export default function PortfolioPreview({ body, fields, frontmatter }: Portfoli
                 </ModalBody>
 
                 <ModalBody>
-                    {!isSSR && (
-                        <Suspense fallback={<RenderLoader />}>
-                            <PostBody content={body} />
-                        </Suspense>
-                    )}
+                    <PostBody content={body} />
                 </ModalBody>
 
                 <ModalFooter>

--- a/src/components/postPreview.tsx
+++ b/src/components/postPreview.tsx
@@ -1,30 +1,24 @@
-import React, { lazy, Suspense } from 'react'
+import React from 'react'
 import { Card, CardBody, CardFooter, CardText } from 'reactstrap'
-const Avatar = lazy(() => import('./avatar'))
-const PostImage = lazy(() => import('./postImage'))
-const PostSubtitle = lazy(() => import('./postSubtitle'))
-const PostTitle = lazy(() => import('./postTitle'))
-import RenderLoader from './renderLoader'
+import Avatar from './avatar'
+import PostImage from './postImage'
+import PostSubtitle from './postSubtitle'
+import PostTitle from './postTitle'
 import truncateText from '../utils/truncateText'
 import { PostBasicProps } from '../types'
 
 export default function PostPreview({ fields, frontmatter }: PostBasicProps) {
-    const isSSR = typeof window === "undefined";
     return (
         <Card>
-            {!isSSR && (
-                <Suspense fallback={<RenderLoader />}>
-                    <CardBody>
-                        <PostImage path={true} slug={fields.slug} title={frontmatter.title} picture={frontmatter.cover.childImageSharp} rounded={true} height={180} />
-                        <PostTitle path={true} slug={fields.slug} title={frontmatter.title} />
-                        <PostSubtitle className='mb-2' date={frontmatter.date} tags={frontmatter.tags} />
-                        <CardText>{truncateText(frontmatter.excerpt, 150)}</CardText>
-                    </CardBody>
-                    <CardFooter>
-                        <Avatar name={frontmatter.author} />
-                    </CardFooter>
-                </Suspense>
-            )}
+            <CardBody>
+                <PostImage path={true} slug={fields.slug} title={frontmatter.title} picture={frontmatter.cover.childImageSharp} rounded={true} height={180} />
+                <PostTitle path={true} slug={fields.slug} title={frontmatter.title} />
+                <PostSubtitle className='mb-2' date={frontmatter.date} tags={frontmatter.tags} />
+                <CardText>{truncateText(frontmatter.excerpt, 150)}</CardText>
+            </CardBody>
+            <CardFooter>
+                <Avatar name={frontmatter.author} />
+            </CardFooter>
         </Card>
     );
 }

--- a/src/components/tag.tsx
+++ b/src/components/tag.tsx
@@ -8,12 +8,10 @@ import { TagProps } from '../types'
 
 const Tag = ({ quantity, tag }: TagProps) => {
     return (
-        <Link to={`/tags/${kebabCase(tag.value)}`}>
-            <Badge color='primary' className='tag' href='#'>
-                <IconContext.Provider value={{ size: '1.5rem', className: 'mr-1' }}>{TagIcon(tag.value)}</IconContext.Provider>
-                <span>{tag.value.toUpperCase()}</span>
-                {quantity ? <Badge color="dark" className='tag-count' pill>{tag.count}</Badge> : null}
-            </Badge>
+        <Link to={`/tags/${kebabCase(tag.value)}`} className='tag badge badge-primary'>
+            <IconContext.Provider value={{ size: '1.5rem', className: 'mr-1' }}>{TagIcon(tag.value)}</IconContext.Provider>
+            <span>{tag.value.toUpperCase()}</span>
+            {quantity ? <Badge color="dark" className='tag-count' pill>{tag.count}</Badge> : null}
         </Link>
     );
 }

--- a/src/pages/wiki.tsx
+++ b/src/pages/wiki.tsx
@@ -31,11 +31,11 @@ const Howto = ({ data }: PostQueryProps) => {
     }
 
     data.allMdx.nodes.map(({ id, body, frontmatter }) => {
-        if (frontmatter.tags.includes(metaData.WikiFaq.toLowerCase())) {
+        if (frontmatter.category.includes(metaData.WikiFaq.toLowerCase())) {
             wikisFaq.push(createListItem(id, body, frontmatter))
-        } else if (frontmatter.tags.includes(metaData.WikiPricing.toLowerCase())) {
+        } else if (frontmatter.category.includes(metaData.WikiPricing.toLowerCase())) {
             wikisPricing.push(createListItem(id, body, frontmatter))
-        } else if (frontmatter.tags.includes(metaData.WikiProcedure.toLowerCase())) {
+        } else if (frontmatter.category.includes(metaData.WikiProcedure.toLowerCase())) {
             wikisProcedure.push(createListItem(id, body, frontmatter))
         }
     })
@@ -86,9 +86,9 @@ export const query = graphql`
         id
         body
         frontmatter {
+          category
           date(formatString: "YYYY MMMM D")
           excerpt
-          tags
           title
         }
       }

--- a/src/templates/howtoPostTemplate.tsx
+++ b/src/templates/howtoPostTemplate.tsx
@@ -17,7 +17,6 @@ const PostTemplate = ({ data, location, pageContext }: PostTemplateProps) => {
     const { previous, next } = pageContext;
     const tags = formatPostTags(frontmatter.tags);
 
-    const isSSR = typeof window === "undefined";
     return (
         <Layout>
             <SEO
@@ -42,7 +41,7 @@ const PostTemplate = ({ data, location, pageContext }: PostTemplateProps) => {
 
             <section className='section-fill gray-medium' id={metaData.HowtoTitle}>
                 <Container className='my-auto post-container'>
-                    {!isSSR && <Filter back={true} pathname={location.pathname} className='mb-3' tags={tags} />}
+                    <Filter back={true} pathname={location.pathname} className='mb-3' tags={tags} />
                     <div className='image-container'>
                         <PostImage path={false} title={title} picture={frontmatter.cover.childImageSharp} rounded={true} />
                         <div className='overlay-text rounded'>

--- a/src/templates/howtoTemplate.tsx
+++ b/src/templates/howtoTemplate.tsx
@@ -1,12 +1,11 @@
-import React, { lazy, Suspense } from 'react'
+import React from 'react'
 import { graphql } from 'gatsby'
 import SEO from 'react-seo-component'
 import { Container } from 'reactstrap'
-const FilterCard = lazy(() => import('../components/filterCard'))
+import FilterCard from '../components/filterCard'
 import Layout from '../components/layout'
 import Pagination from '../components/pagination'
 import PostMore from '../components/postMore'
-import RenderLoader from '../components/renderLoader'
 import { PostQueryProps } from '../types'
 import { metaData, navigation } from '../utils/data'
 import formatAllTags from '../utils/formatAllTags'
@@ -16,7 +15,6 @@ const HowtoTemplate = ({ data, location, pageContext }: PostQueryProps) => {
     const tags = formatAllTags(data.allMdx.group);
     const { currentPage, numPages } = pageContext;
 
-    const isSSR = typeof window === "undefined";
     return (
         <>
             <Layout>
@@ -34,13 +32,9 @@ const HowtoTemplate = ({ data, location, pageContext }: PostQueryProps) => {
 
                 <section className='section-fill blue-light' id={metaData.HowtoTitle}>
                     <Container className='my-auto'>
-                        {!isSSR && 
-                            <Suspense fallback={<RenderLoader />}>
-                                <FilterCard pathname={location.pathname} tags={tags} />
-                            </Suspense>
-                        }
+                        <FilterCard pathname={location.pathname} tags={tags} />
                         {posts.length > 0 && <PostMore posts={posts} />}
-                        {!isSSR && <Pagination currentPage={currentPage} numPages={numPages} path={navigation.howto} />}
+                        <Pagination currentPage={currentPage} numPages={numPages} path={navigation.howto} />
                     </Container>
                 </section>
             </Layout>

--- a/src/templates/portfolioPostTemplate.tsx
+++ b/src/templates/portfolioPostTemplate.tsx
@@ -17,7 +17,6 @@ const PortfolioTemplate = ({ data, location, pageContext }: PostTemplateProps) =
     const { previous, next } = pageContext;
     const tags = formatPostTags(frontmatter.tags);
 
-    const isSSR = typeof window === "undefined";
     return (
         <Layout>
             <SEO
@@ -42,7 +41,7 @@ const PortfolioTemplate = ({ data, location, pageContext }: PostTemplateProps) =
 
             <section className='section-fill gray-medium' id={metaData.PortfolioTitle}>
                 <Container className='my-auto post-container'>
-                    {!isSSR && <Filter back={true} pathname={location.pathname} className='mb-3' tags={tags} />}
+                    <Filter back={true} pathname={location.pathname} className='mb-3' tags={tags} />
                     <div className='image-container'>
                         <PostImage path={false} title={title} picture={frontmatter.cover.childImageSharp} rounded={true} />
                         <div className='overlay-text rounded'>

--- a/src/templates/portfolioTemplate.tsx
+++ b/src/templates/portfolioTemplate.tsx
@@ -1,12 +1,11 @@
-import React, { lazy, Suspense } from 'react'
+import React from 'react'
 import { graphql } from 'gatsby'
 import SEO from 'react-seo-component'
 import { Container } from 'reactstrap'
-const FilterCard = lazy(() => import('../components/filterCard'))
+import FilterCard from '../components/filterCard'
 import Layout from '../components/layout'
 import Pagination from '../components/pagination'
 import PortfolioEntries from '../components/portfolioEntries'
-import RenderLoader from '../components/renderLoader'
 import { PostQueryProps } from '../types'
 import { metaData, navigation } from '../utils/data'
 import formatAllTags from '../utils/formatAllTags'
@@ -16,7 +15,6 @@ const PortfolioTemplate = ({ data, location, pageContext }: PostQueryProps) => {
     const tags = formatAllTags(data.allMdx.group);
     const { currentPage, numPages } = pageContext;
 
-    const isSSR = typeof window === "undefined";
     return (
         <>
             <Layout>
@@ -34,13 +32,9 @@ const PortfolioTemplate = ({ data, location, pageContext }: PostQueryProps) => {
 
                 <section className='section-fill blue-medium' id={metaData.PortfolioTitle}>
                     <Container className='text-left my-auto'>
-                        {!isSSR && (
-                            <Suspense fallback={<RenderLoader />}>
-                                <FilterCard pathname={location.pathname} tags={tags} />
-                            </Suspense>
-                        )}
+                        <FilterCard pathname={location.pathname} tags={tags} />
                         {entries.length > 0 && <PortfolioEntries posts={entries} />}
-                        {!isSSR && <Pagination currentPage={currentPage} numPages={numPages} path={navigation.portfolio} />}
+                        <Pagination currentPage={currentPage} numPages={numPages} path={navigation.portfolio} />
                     </Container>
                 </section>
             </Layout>

--- a/src/templates/tagsTemplate.tsx
+++ b/src/templates/tagsTemplate.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql, Link } from 'gatsby'
+import { graphql } from 'gatsby'
 import SEO from 'react-seo-component'
 import { Container } from 'reactstrap'
 import FilterCard from '../components/filterCard'
@@ -12,7 +12,6 @@ import formatAllTags from '../utils/formatAllTags'
 const Tag = ({ data, location, pageContext }: PostQueryProps) => {
     const posts = data.allMdx.nodes;
     const tags = formatAllTags([pageContext.tag]);
-    const { currentPage, numPages } = pageContext;
     return (
         <>
             <Layout>
@@ -32,12 +31,6 @@ const Tag = ({ data, location, pageContext }: PostQueryProps) => {
                     <Container className='my-auto'>
                         <FilterCard pathname={location.pathname} tags={tags} />
                         {posts.length > 0 && <PostMore posts={posts} />}
-                        <hr />
-                        {Array.from({ length: numPages }, (_, i) => (
-                            <Link key={`pagination-number${i + 1}`} to={`/portfolio/${i === 0 ? "" : i + 1}`}>
-                                {i + 1}
-                            </Link>
-                        ))}
                     </Container>
                 </section>
             </Layout>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -125,6 +125,7 @@ export type PaginationProps ={
 // === Begin Posts ===
 type FrontMatterProps = {
     author: string
+    category?: string
     cover: {
         childImageSharp: ChildImageSharpFluid
         publicURL: string
@@ -174,11 +175,11 @@ export type PostQueryProps = {
     },
     location: Location
     pageContext?: {
-        currentPage: number
-        numPages: number
-        slug: string
-        tag: string
-        tagRaw: {
+        currentPage?: number
+        numPages?: number
+        slug?: string
+        tag?: string
+        tagRaw?: {
             fieldValue: string
         }
     }


### PR DESCRIPTION
To fix issue #55 I had to remove lazy loading.  After that, new issues popped up:
- pages for wiki tags failed due to missing (non-existing) cover image -> fixed by changing "tags" to "category" in frontmatter of wiki items
- badges for tags rendered incorrectly after refresh. Fixed by moving classes to wrapping `Link` component